### PR TITLE
Added functionality to upload via command line tools. 

### DIFF
--- a/api/files.go
+++ b/api/files.go
@@ -20,9 +20,12 @@ func FileOptionsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func FileCreateHandler(w http.ResponseWriter, r *http.Request) {
+
+	_, err_apikey := AuthApiKey(r)
+
 	// #### CHECK IF AUTHENTICATED ####
 	_, err := AuthSession(r)
-	if err != nil {
+	if err != nil && err_apikey != nil {
 		DumpResponse(w, "unauthorized", http.StatusUnauthorized, API_ERROR_BAD_AUTHENTICATION, nil)
 		return
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -106,9 +106,11 @@ func (c *Config) HandleSetup() error {
 		if len(username) > 0 && len(password) > 0 {
 			phash, err := bcrypt.GenerateFromPassword([]byte(password), 10)
 			if err == nil {
+				uak := utils.GenRandomString(32)
 				o := &storage.DbUser{
 					Name:     username,
 					Password: string(phash),
+					ApiKey:   uak,
 				}
 
 				storage.UserDelete(1)

--- a/core/server.go
+++ b/core/server.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
 	"github.com/gorilla/mux"
 	"golang.org/x/crypto/acme"
 
@@ -156,6 +155,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					s.r.ServeHTTP(w, r)
 					return
 				}
+			}
+			if _, err := api.AuthApiKey(r); err == nil {
+				s.r.ServeHTTP(w,r)
+				return
 			}
 
 			if len(Cfg.GetRedirectUrl()) > 0 {

--- a/storage/db_user.go
+++ b/storage/db_user.go
@@ -9,6 +9,7 @@ type DbUser struct {
 	Name       string `json:"name"`
 	SearchName string `json:"search_name" storm:"unique"`
 	Password   string `json:"password"`
+	ApiKey     string `json:"apikey"`
 }
 
 func UserCreate(o *DbUser) (*DbUser, error) {
@@ -56,4 +57,12 @@ func UserDelete(id int) error {
 		return err
 	}
 	return nil
+}
+func UserGetByApiKey(apikey string) (*DbUser, error) {
+        var o DbUser
+        err := db.One("ApiKey", apikey, &o)
+        if err != nil {
+                return nil, err
+        }
+        return &o, nil
 }

--- a/www/pages/components/file_view.vue.js
+++ b/www/pages/components/file_view.vue.js
@@ -221,10 +221,20 @@ var appFileView = Vue.component("app-file-view", {
 				</form>
 			</div>
         </div>
-        <div class="row row-info">
+
+	   <div class="curl-cmd">
+	   <a class="btn-copy" ref="copyCurlUpload" href @click.prevent="copyCurl()">
+   		<button class="btn btn-outline-success btn-copy-link col-xs-12 col-sm-8 offset-sm-2 col-md-6 offset-md-3" v-tooltip:bottom="'Copy cURL command'">
+        		<i class="fas fa-copy" style="margin-right: 5px"></i>Upload via cURL command
+   		 </button>
+   	    </a>
+         </div>
+
+	<div class="row row-info">
             <div class="server-status col-xs-12 col-sm-8 offset-sm-2 col-md-6 offset-md-3">
                 free: <strong>{{ server_info.disk_free | prettyBytes }}</strong> &bull; used: <strong>{{ server_info.disk_used | prettyBytes }}</strong>
             </div>
+
         </div>
 		<!-- 		<button @click="doShuffle()">Shuffle</button>
 		-->
@@ -272,7 +282,9 @@ var appFileView = Vue.component("app-file-view", {
             server_info: {
                 disk_free: 0,
                 disk_used: 0
-            }
+            },
+            curlCommand: "curl -X POST -H \"Authorization: <Upload Key>\" -F \"file=@path/to/file\" http://<Pwndrop-host>/api/v1/files",
+
 		};
     },
     computed: {
@@ -281,6 +293,18 @@ var appFileView = Vue.component("app-file-view", {
         }
     },
 	methods: {
+                copyCurl() {
+                        var l = window.location;
+                        var filesurl = l.protocol + "//" + l.hostname;
+                        if (l.port != "" && (l.port != 443 && l.port != 80)) {
+                                filesurl += ":" + l.port;
+                        }
+                        filesurl += escape("/api/v1/files");
+                        this.curlCommand = "curl -X POST -H \"Authorization: "   + localStorage.Authorization + "\" -F \"file=@path/to/file\" ";
+			this.curlCommand = this.curlCommand + " " + filesurl;
+                        this.$refs.copyCurlUpload.setAttribute("data-clipboard-text", this.curlCommand);
+                },
+
 		doShuffle() {
 			this.uploads = _.shuffle(this.uploads);
 		},
@@ -693,6 +717,7 @@ var appFileView = Vue.component("app-file-view", {
                 .catch(error => {
                     console.log(error);
                 });
+
         }
 	},
 	created() {
@@ -702,7 +727,17 @@ var appFileView = Vue.component("app-file-view", {
 				t.isDragging = true;
 			}
         });
-        this.syncServerInfo();
+
+        this.mainBus.$on('loggedIn', (username) => {
+                        console.log("LoggedIN");
+                        console.log(username);
+                        this.Username = username;
+                        this.doLogin = false;
+                        this.isLoggedIn = true;
+        });
+
+
+	this.syncServerInfo();
         this.refresh();
 	}
 })

--- a/www/pages/components/login.vue.js
+++ b/www/pages/components/login.vue.js
@@ -71,7 +71,7 @@ var appLogin = Vue.component("app-login", {
 			url: Config.Hostname + Config.AdminDir + "/" + Config.ApiPath,
 			Username: "",
             Password: "",
-            status: "",
+            status: ""
 		};
 	},
     computed: {
@@ -102,6 +102,7 @@ var appLogin = Vue.component("app-login", {
                     console.log(response);
                     console.log(response.data.data.username);
 					this.mainBus.$emit("loggedIn", response.data.data.username);
+					localStorage.setItem("Authorization", response.data.data.apikey);
 				})
 				.catch(error => {
                     if (error.response.status == 401)


### PR DESCRIPTION
I needed a way to automate uploading Pwns to this amazing tool, so I modified it a bit, to generate and accept API key.
Using the key, it generates curl command that can be copied from the GUI in order to upload new files.

An Upload with cURL button added under the main Upload button. 
For the back-end API, added API key validation via Authorization header. The API key (32 chars) is generated with the user creation.
The Authorization key is saved in the application database and in the user's local storage on a successful login, it then loaded from the storage when clicking the new button.
By providing the authorization key in the "Authorization" header in an HTTP request, the application skips the "secret path" and session ID checks, but allow **only file creation**. It means that this is more an upload key than API key since it only authorizes the use of FileCreateHandler under api/files.go. 

*Sidenote, when a client uses the upload key, it skips the secret path session validation for any request (see change at core/server.go).

Demo GIF:
![pwndrop-curl-demo](https://user-images.githubusercontent.com/50264063/90645990-554abd80-e23f-11ea-85ab-5032457f7523.gif)

High quality:
https://youtu.be/TVOlB7X6TEU

